### PR TITLE
Fix child_boundary() for Float32 cells

### DIFF
--- a/src/cell.jl
+++ b/src/cell.jl
@@ -39,7 +39,7 @@ show(io::IO, cell::Cell) = print(io, "Cell: $(cell.boundary)")
 @inline getindex(cell::Cell, I...) = getindex(cell.children, I...)
 
 function child_boundary(cell::Cell, indices)
-    HyperRectangle(cell.boundary.origin + 0.5 * (SVector(indices) - 1) .* cell.boundary.widths,
+    HyperRectangle(cell.boundary.origin + 1//2 * (SVector(indices) - 1) .* cell.boundary.widths,
                    cell.boundary.widths / 2)
 end
 


### PR DESCRIPTION
I encountered the following issue using vectors of `Float32` constructing the cell:
```julia
julia> using RegionTrees

julia> function tf1()
           root = Cell(SVector(0f0, 0f0, 0f0), SVector(1f0, 1f0, 1f0))
               split!(root)
               end
tf1 (generic function with 1 method)

julia> tf1()
ERROR: MethodError: no method matching HyperRectangle(::SArray{Tuple{3},Float64,1,3}, ::SArray{Tuple{3},Float32,1,3})
Closest candidates are:
  HyperRectangle(::SArray{Tuple{N},T,1,N}, ::SArray{Tuple{N},T,1,N}) where {N, T} at C:\Users\cstamas\.julia\dev\RegionTrees\src\hyperrectangle.jl:2
Stacktrace:
 [1] child_boundary(::Cell{Nothing,3,Float32,8}, ::Tuple{Int64,Int64,Int64}) at C:\Users\cstamas\.julia\dev\RegionTrees\src\cell.jl:42
 [2] macro expansion at C:\Users\cstamas\.julia\dev\RegionTrees\src\cell.jl:75 [inlined]
 [3] split!(::Cell{Nothing,3,Float32,8}, ::RegionTrees.TwosArray{3,Nothing,8}) at C:\Users\cstamas\.julia\dev\RegionTrees\src\cell.jl:64
 [4] split!(::Cell{Nothing,3,Float32,8}, ::Function) at C:\Users\cstamas\.julia\dev\RegionTrees\src\cell.jl:67
 [5] split!(::Cell{Nothing,3,Float32,8}) at C:\Users\cstamas\.julia\dev\RegionTrees\src\cell.jl:60
 [6] tf1() at .\REPL[3]:3
 [7] top-level scope at none:0
```
With this patch it works fine:
```julia
julia> tf1()
Cell: HyperRectangle{3,Float32}(Float32[0.0, 0.0, 0.0], Float32[1.0, 1.0, 1.0])
```

Sorry for the merge commit hope it's still fine.