### PR TITLE
fix code for deprecated syntax in StaticArrays@0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Interpolations = "0.9, 0.10, 0.11, 0.12"
 IterTools = "1"
-StaticArrays = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11"
+StaticArrays = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12"
 julia = "1"
 
 [extras]

--- a/examples/adaptive_distance_fields/adaptive_distance_fields.jl
+++ b/examples/adaptive_distance_fields/adaptive_distance_fields.jl
@@ -19,7 +19,7 @@ function evaluate(cell::Cell{D}, point::AbstractArray) where D <: AbstractInterp
 end
 
 function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
-    coords = (point - boundary.origin) ./ boundary.widths + 1
+    coords = (point .- boundary.origin) ./ boundary.widths .+ 1
     evaluate(interp, coords)
 end
 

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -41,7 +41,7 @@ show(io::IO, cell::Cell) = print(io, "Cell: $(cell.boundary)")
 function child_boundary(cell::Cell, indices)
     half_widths = cell.boundary.widths ./ 2
     HyperRectangle(
-        cell.boundary.origin + (SVector(indices) - 1) .* half_widths,
+        cell.boundary.origin .+ (SVector(indices) .- 1) .* half_widths,
         half_widths)
 end
 


### PR DESCRIPTION
`StaticArrays@0.12.0` introduced some deprication warnings and this PR updates the code to be compatible with it.

## Before

```julia
rttest) pkg> test RegionTrees
   Testing RegionTrees
 Resolving package versions...
    Status `C:\Users\Laci\AppData\Local\Temp\jl_eIE1BX\Manifest.toml`
  [13072b0f] AxisAlgorithms v1.0.0
  [34da2185] Compat v2.2.0
  [a98d9a8b] Interpolations v0.12.5
  [c8e1da08] IterTools v1.3.0
  [6fe1bfb0] OffsetArrays v0.11.4
  [c84ed2f1] Ratios v0.3.1
  [dee08c22] RegionTrees v0.3.0+ [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.12.1
  [efce3f68] WoodburyMatrices v0.4.1
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [ade2ca70] Dates  [`@stdlib/Dates`]
  [8bb1440f] DelimitedFiles  [`@stdlib/DelimitedFiles`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [76f85450] LibGit2  [`@stdlib/LibGit2`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [a63ad114] Mmap  [`@stdlib/Mmap`]
  [44cfe95a] Pkg  [`@stdlib/Pkg`]
  [de0858da] Printf  [`@stdlib/Printf`]
  [3fa0cd96] REPL  [`@stdlib/REPL`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [ea8e919c] SHA  [`@stdlib/SHA`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [1a1011a3] SharedArrays  [`@stdlib/SharedArrays`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [2f01184e] SparseArrays  [`@stdlib/SparseArrays`]
  [10745b16] Statistics  [`@stdlib/Statistics`]
  [8dfed614] Test  [`@stdlib/Test`]
  [cf7118a7] UUIDs  [`@stdlib/UUIDs`]
  [4ec0a83e] Unicode  [`@stdlib/Unicode`]
Test Summary: | Pass  Total
vertices      |    9      9
┌ Warning: `a::StaticArray - b::Number` is deprecated, use `a .- b` instead.
│   caller = child_boundary(::Cell{Int64,3,Float64,8}, ::Tuple{Int64,Int64,Int64}) at cell.jl:42
└ @ RegionTrees C:\Users\Laci\.julia\dev\RegionTrees\src\cell.jl:42
Test Summary:        | Pass  Total
parents and children |   17     17
Test Summary:   | Pass  Total
type promotions |    2      2
Test Summary: | Pass  Total
find leaf     |    3      3
┌ Warning: `a::StaticArray - b::Number` is deprecated, use `a .- b` instead.
│   caller = child_boundary(::Cell{Nothing,2,Float64,4}, ::Tuple{Int64,Int64}) at cell.jl:42
└ @ RegionTrees C:\Users\Laci\.julia\dev\RegionTrees\src\cell.jl:42
Test Summary: | Pass  Total
find parents  |    5      5
Test Summary: | Pass  Total
twosarray     |   37     37
┌ Warning: `a::StaticArray + b::Number` is deprecated, use `a .+ b` instead.
│   caller = evaluate at adaptive_distance_fields.jl:22 [inlined]
└ @ Core C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:22
┌ Warning: `a::StaticArray - b::Number` is deprecated, use `a .- b` instead.
│   caller = child_boundary(::Cell{Interpolations.BSplineInterpolation{Float64,2,SArray{Tuple{2,2},Float64,2,4},Interpolations.BSpline{Interpolations.Linear},Tuple{Base.Slice{UnitRange{Int64}},Base.Slice{UnitRange{Int64}}}},2,Float64,4}, ::Tuple{Int64,Int64}) at cell.jl:42
└ @ RegionTrees C:\Users\Laci\.julia\dev\RegionTrees\src\cell.jl:42
┌ Warning: `a::StaticArray + b::Number` is deprecated, use `a .+ b` instead.
│   caller = evaluate at adaptive_distance_fields.jl:22 [inlined]
└ @ Core C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:22
┌ Warning: `a::StaticArray + b::Number` is deprecated, use `a .+ b` instead.
│   caller = evaluate at adaptive_distance_fields.jl:22 [inlined]
└ @ Core C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:22
Test Summary:                      | Pass  Broken  Total
adaptively sampled distance fields |  200       2    202
   Testing RegionTrees tests passed

(rttest) pkg> st
    Status `C:\Users\Laci\Documents\Coding\rttest\Project.toml`
  [dee08c22] RegionTrees v0.3.0+ [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.12.1
```

And
## After

```
(rttest) pkg> test RegionTrees
   Testing RegionTrees
 Resolving package versions...
    Status `C:\Users\Laci\AppData\Local\Temp\jl_RAFq2u\Manifest.toml`
  [13072b0f] AxisAlgorithms v1.0.0
  [34da2185] Compat v2.2.0
  [a98d9a8b] Interpolations v0.12.5
  [c8e1da08] IterTools v1.3.0
  [6fe1bfb0] OffsetArrays v0.11.4
  [c84ed2f1] Ratios v0.3.1
  [dee08c22] RegionTrees v0.3.0 [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.12.1
  [efce3f68] WoodburyMatrices v0.4.1
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [ade2ca70] Dates  [`@stdlib/Dates`]
  [8bb1440f] DelimitedFiles  [`@stdlib/DelimitedFiles`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [76f85450] LibGit2  [`@stdlib/LibGit2`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [a63ad114] Mmap  [`@stdlib/Mmap`]
  [44cfe95a] Pkg  [`@stdlib/Pkg`]
  [de0858da] Printf  [`@stdlib/Printf`]
  [3fa0cd96] REPL  [`@stdlib/REPL`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [ea8e919c] SHA  [`@stdlib/SHA`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [1a1011a3] SharedArrays  [`@stdlib/SharedArrays`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [2f01184e] SparseArrays  [`@stdlib/SparseArrays`]
  [10745b16] Statistics  [`@stdlib/Statistics`]
  [8dfed614] Test  [`@stdlib/Test`]
  [cf7118a7] UUIDs  [`@stdlib/UUIDs`]
  [4ec0a83e] Unicode  [`@stdlib/Unicode`]
Test Summary: | Pass  Total
vertices      |    9      9
Test Summary:        | Pass  Total
parents and children |   17     17
Test Summary:   | Pass  Total
type promotions |    2      2
Test Summary: | Pass  Total
find leaf     |    3      3
Test Summary: | Pass  Total
find parents  |    5      5
Test Summary:     | Pass  Total
non-float64 types |    1      1
Test Summary: | Pass  Total
twosarray     |   37     37
Test Summary:                      | Pass  Broken  Total
adaptively sampled distance fields |  200       2    202
   Testing RegionTrees tests passed
```

Tried it with different version of `StaticArrays`. And for some, tests fail:

## `StaticArrays@0.8.3`
```
(rttest) pkg> st
    Status `C:\Users\Laci\Documents\Coding\rttest\Project.toml`
  [dee08c22] RegionTrees v0.3.0 [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.8.3

(rttest) pkg> test RegionTrees
   Testing RegionTrees
 Resolving package versions...
    Status `C:\Users\Laci\AppData\Local\Temp\jl_wMklhZ\Manifest.toml`
  [13072b0f] AxisAlgorithms v1.0.0
  [34da2185] Compat v2.2.0
  [a98d9a8b] Interpolations v0.12.5
  [c8e1da08] IterTools v1.3.0
  [6fe1bfb0] OffsetArrays v0.11.4
  [c84ed2f1] Ratios v0.3.1
  [dee08c22] RegionTrees v0.3.0 [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.8.3
  [efce3f68] WoodburyMatrices v0.4.1
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [ade2ca70] Dates  [`@stdlib/Dates`]
  [8bb1440f] DelimitedFiles  [`@stdlib/DelimitedFiles`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [76f85450] LibGit2  [`@stdlib/LibGit2`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [a63ad114] Mmap  [`@stdlib/Mmap`]
  [44cfe95a] Pkg  [`@stdlib/Pkg`]
  [de0858da] Printf  [`@stdlib/Printf`]
  [3fa0cd96] REPL  [`@stdlib/REPL`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [ea8e919c] SHA  [`@stdlib/SHA`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [1a1011a3] SharedArrays  [`@stdlib/SharedArrays`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [2f01184e] SparseArrays  [`@stdlib/SparseArrays`]
  [10745b16] Statistics  [`@stdlib/Statistics`]
  [8dfed614] Test  [`@stdlib/Test`]
  [cf7118a7] UUIDs  [`@stdlib/UUIDs`]
  [4ec0a83e] Unicode  [`@stdlib/Unicode`]
Test Summary: | Pass  Total
vertices      |    9      9
Test Summary:        | Pass  Total
parents and children |   17     17
Test Summary:   | Pass  Total
type promotions |    2      2
Test Summary: | Pass  Total
find leaf     |    3      3
Test Summary: | Pass  Total
find parents  |    5      5
Test Summary:     | Pass  Total
non-float64 types |    1      1
Test Summary: | Pass  Total
twosarray     |   37     37
adaptively sampled distance fields: Error During Test at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:10
  Test threw exception
  Expression: evaluate(root, [0, 0]) == 0
  UndefVarError: _max not defined
  Stacktrace:
   [1] getproperty at .\Base.jl:13 [inlined]
   [2] Base.Broadcast.BroadcastStyle(::StaticArrays.StaticArrayStyle{1}, ::Base.Broadcast.DefaultArrayStyle{1}) at C:\Users\Laci\.julia\packages\StaticArrays\Ze5H3\src\broadcast.jl:15
   [3] result_style at .\broadcast.jl:435 [inlined]
   [4] combine_styles at .\broadcast.jl:411 [inlined]
   [5] broadcasted at .\broadcast.jl:1237 [inlined]
   [6] evaluate(::Interpolations.BSplineInterpolation{Float64,2,SArray{Tuple{2,2},Float64,2,4},Interpolations.BSpline{Interpolations.Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, ::HyperRectangle{2,Float64}, ::Array{Int64,1}) at C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:22
   [7] evaluate(::Cell{Interpolations.BSplineInterpolation{Float64,2,SArray{Tuple{2,2},Float64,2,4},Interpolations.BSpline{Interpolations.Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},2,Float64,4}, ::Array{Int64,1}) at C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:18
   [8] top-level scope at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:10
   [9] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\Test\src\Test.jl:1107
   [10] top-level scope at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:2

Test Summary:                      | Pass  Error  Broken  Total
adaptively sampled distance fields |  199      1       2    202
ERROR: LoadError: LoadError: Some tests did not pass: 199 passed, 0 failed, 1 errored, 2 broken.
in expression starting at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:1
in expression starting at C:\Users\Laci\.julia\dev\RegionTrees\test\runtests.jl:9
ERROR: Package RegionTrees errored during testing
```

## `StaticArrays@0.9.2`:

```
(rttest) pkg> add StaticArrays@0.9
 Resolving package versions...
 Installed StaticArrays ─ v0.9.2
  Updating `C:\Users\Laci\Documents\Coding\rttest\Project.toml`
  [90137ffa] ↑ StaticArrays v0.8.3 ⇒ v0.9.2
  Updating `C:\Users\Laci\Documents\Coding\rttest\Manifest.toml`
  [90137ffa] ↑ StaticArrays v0.8.3 ⇒ v0.9.2

(rttest) pkg> test RegionTrees
   Testing RegionTrees
 Resolving package versions...
    Status `C:\Users\Laci\AppData\Local\Temp\jl_hXlRNS\Manifest.toml`
  [13072b0f] AxisAlgorithms v1.0.0
  [34da2185] Compat v2.2.0
  [a98d9a8b] Interpolations v0.12.5
  [c8e1da08] IterTools v1.3.0
  [6fe1bfb0] OffsetArrays v0.11.4
  [c84ed2f1] Ratios v0.3.1
  [dee08c22] RegionTrees v0.3.0 [`C:\Users\Laci\.julia\dev\RegionTrees`]
  [90137ffa] StaticArrays v0.9.2
  [efce3f68] WoodburyMatrices v0.4.1
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [ade2ca70] Dates  [`@stdlib/Dates`]
  [8bb1440f] DelimitedFiles  [`@stdlib/DelimitedFiles`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [76f85450] LibGit2  [`@stdlib/LibGit2`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [a63ad114] Mmap  [`@stdlib/Mmap`]
  [44cfe95a] Pkg  [`@stdlib/Pkg`]
  [de0858da] Printf  [`@stdlib/Printf`]
  [3fa0cd96] REPL  [`@stdlib/REPL`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [ea8e919c] SHA  [`@stdlib/SHA`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [1a1011a3] SharedArrays  [`@stdlib/SharedArrays`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [2f01184e] SparseArrays  [`@stdlib/SparseArrays`]
  [10745b16] Statistics  [`@stdlib/Statistics`]
  [8dfed614] Test  [`@stdlib/Test`]
  [cf7118a7] UUIDs  [`@stdlib/UUIDs`]
  [4ec0a83e] Unicode  [`@stdlib/Unicode`]
Test Summary: | Pass  Total
vertices      |    9      9
Test Summary:        | Pass  Total
parents and children |   17     17
Test Summary:   | Pass  Total
type promotions |    2      2
Test Summary: | Pass  Total
find leaf     |    3      3
Test Summary: | Pass  Total
find parents  |    5      5
Test Summary:     | Pass  Total
non-float64 types |    1      1
Test Summary: | Pass  Total
twosarray     |   37     37
adaptively sampled distance fields: Error During Test at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:10
  Test threw exception
  Expression: evaluate(root, [0, 0]) == 0
  UndefVarError: _max not defined
  Stacktrace:
   [1] getproperty at .\Base.jl:13 [inlined]
   [2] Base.Broadcast.BroadcastStyle(::StaticArrays.StaticArrayStyle{1}, ::Base.Broadcast.DefaultArrayStyle{1}) at C:\Users\Laci\.julia\packages\StaticArrays\WmJnA\src\broadcast.jl:15
   [3] result_style at .\broadcast.jl:435 [inlined]
   [4] combine_styles at .\broadcast.jl:411 [inlined]
   [5] broadcasted at .\broadcast.jl:1237 [inlined]
   [6] evaluate(::Interpolations.BSplineInterpolation{Float64,2,SArray{Tuple{2,2},Float64,2,4},Interpolations.BSpline{Interpolations.Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, ::HyperRectangle{2,Float64}, ::Array{Int64,1}) at C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:22
   [7] evaluate(::Cell{Interpolations.BSplineInterpolation{Float64,2,SArray{Tuple{2,2},Float64,2,4},Interpolations.BSpline{Interpolations.Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},2,Float64,4}, ::Array{Int64,1}) at C:\Users\Laci\.julia\dev\RegionTrees\examples\adaptive_distance_fields\adaptive_distance_fields.jl:18
   [8] top-level scope at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:10
   [9] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.3\Test\src\Test.jl:1107
   [10] top-level scope at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:2

Test Summary:                      | Pass  Error  Broken  Total
adaptively sampled distance fields |  199      1       2    202
ERROR: LoadError: LoadError: Some tests did not pass: 199 passed, 0 failed, 1 errored, 2 broken.
in expression starting at C:\Users\Laci\.julia\dev\RegionTrees\test\asdfs.jl:1
in expression starting at C:\Users\Laci\.julia\dev\RegionTrees\test\runtests.jl:9
ERROR: Package RegionTrees errored during testing
```

With `StaticArrays@0.10` and above it works perfectly. May be versions before `0.10` should be removed from compat?
