### PR TITLE
fix adaptivesampling! to only split leaf cells

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,12 +24,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -42,6 +42,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/src/adaptivesampling.jl
+++ b/src/adaptivesampling.jl
@@ -9,8 +9,12 @@ function adaptivesampling!(root::Cell, refinery::AbstractRefinery)
         (cell, indices) -> refine_data(refinery, cell, indices)
     while !isempty(refinement_queue)
         cell = pop!(refinement_queue)
-        if needs_refinement(refinery, cell)
-            split!(cell, refine_function)
+        if isleaf(cell)
+            if needs_refinement(refinery, cell)
+                split!(cell, refine_function)
+                append!(refinement_queue, children(cell))
+            end
+        else
             append!(refinement_queue, children(cell))
         end
     end


### PR DESCRIPTION
Subsequent calls of `adaptivesampling!` fail because it just collects the cells and splits them if required. MWE from example:

```julia
using RegionTrees
using StaticArrays: SVector
import RegionTrees: AbstractRefinery, needs_refinement, refine_data

struct MyRefinery <: AbstractRefinery
    tolerance::Float64
end

function needs_refinement(r::MyRefinery, cell)
    maximum(cell.boundary.widths) > r.tolerance
end

function refine_data(r::MyRefinery, cell::Cell, indices)
    boundary = child_boundary(cell, indices)
    "child with widths: $(boundary.widths)"
end

r = MyRefinery(0.05)
root = Cell(SVector(0., 0), SVector(1., 1), "root")
```
Then calling `adaptivesampling!` twice:

```julia
julia> root = Cell(SVector(0., 0), SVector(1., 1), "root")
Cell: HyperRectangle{2, Float64}([0.0, 0.0], [1.0, 1.0])

julia> adaptivesampling!(root, r)
Cell: HyperRectangle{2, Float64}([0.0, 0.0], [1.0, 1.0])

julia> adaptivesampling!(root, r)
ERROR: AssertionError: isleaf(cell)
Stacktrace:
 [1] macro expansion
   @ C:\Users\user\.julia\packages\RegionTrees\rosFd\src\cell.jl:76 [inlined]
 [2] split!(cell::Cell{String, 2, Float64, 4}, child_data::RegionTrees.TwosArray{2, String, 4})
   @ RegionTrees C:\Users\user\.julia\packages\RegionTrees\rosFd\src\cell.jl:65
 [3] split!
   @ C:\Users\user\.julia\packages\RegionTrees\rosFd\src\cell.jl:69 [inlined]
 [4] adaptivesampling!(root::Cell{String, 2, Float64, 4}, refinery::MyRefinery)
   @ RegionTrees C:\Users\user\.julia\packages\RegionTrees\rosFd\src\adaptivesampling.jl:13
 [5] top-level scope
   @ REPL[11]:1
```

This PR fixes this by only splitting leaf cells and adding the children of others instead so subsequent calls work as intended.