### PR TITLE
allow Interpolations up to 0.16

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13"
+Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16"
 IterTools = "1"
 StaticArrays = "0.12, 1"
 julia = "1"


### PR DESCRIPTION
Tests seem to pass with Interpolations.jl v0.16.2. (Tested locally. To run CI, the CI code needs to be updated: 6eeb3c56fb7bc666c74bfa3dfb4864cf0d6f7079)

Though from the [Release Notes](https://github.com/JuliaMath/Interpolations.jl/releases):
- Julia 1.6 is required with v0.15
- Julia 1.9 is required with v0.16