### PR TITLE
fix type instability in center for non-Float64 types

### DIFF
--- a/src/hyperrectangle.jl
+++ b/src/hyperrectangle.jl
@@ -14,7 +14,7 @@ end
     Expr(:call, :TwosArray, verts...)
 end
 
-center(rect::HyperRectangle) = rect.origin + 0.5 * rect.widths
+center(rect::HyperRectangle) = rect.origin + rect.widths / 2
 
 convert(::Type{HyperRectangle{N, T2}}, r::HyperRectangle{N, T1}) where {N, T1, T2} =
     HyperRectangle{N, T2}(convert(SVector{N, T2}, r.origin),

--- a/test/cell.jl
+++ b/test/cell.jl
@@ -62,4 +62,6 @@ end
     root = Cell(SVector(0f0, 0f0, 0f0), SVector(1f0, 1f0, 1f0))
     split!(root)
     @test length(root.children) == 8
+    @test center(root) == SVector(0.5f0, 0.5f0, 0.5f0)
+    @test typeof(center(root)) == SVector{3, Float32}
 end


### PR DESCRIPTION
Even after #22 I came across this error. Added a test too to cover this case